### PR TITLE
Add listing: Malware Analyst

### DIFF
--- a/skills/malware-analyst.md
+++ b/skills/malware-analyst.md
@@ -1,0 +1,30 @@
+---
+name: "Malware Analyst"
+author: "tomabai"
+github_url: "https://github.com/tomabai/malware-analyst"
+description: "Static-only malware analysis: deobfuscate files, extract IOCs, and write variant-agnostic detection signatures."
+license: "MIT"
+tier: "unreviewed"
+tags: ["malware-analysis", "deobfuscation", "reverse-engineering", "detection-signatures", "ioc-extraction", "static-analysis"]
+integrations: ["Anthropic"]
+date_added: 2026-06-29
+compatible_platforms: ["Claude Code"]
+invocation: "/malware-analyst"
+---
+
+A static-only malware analysis skill that deobfuscates suspicious files, explains what the code does, extracts indicators of compromise, and writes detection signatures — without ever executing the sample.
+
+## What it does
+
+Given an obfuscated script, dropper, or suspicious file, the skill runs a structured six-phase workflow:
+
+1. **Initial Triage** — identify file type, target runtime, and surface-level obfuscation.
+2. **Full Deobfuscation** — peel back every layer (base64, hex, XOR, `eval`/`exec` wrappers, `String.fromCharCode` chains, array-rotation shufflers, custom ciphers), showing each layer. When a layer needs runtime to resolve, it writes a standalone static decryptor against the extracted ciphertext rather than running the malware.
+3. **Behavioral Analysis** — plain-English execution flow plus a capability matrix (dropper, persistence, C2, exfiltration, lateral movement, defense evasion, anti-analysis).
+4. **IOC Extraction** — network, filesystem, behavioral, and cryptographic indicators, each tagged with a confidence level and fully resolved before reporting.
+5. **Detection Signatures** — text-based (grep/YARA/SIEM) and regex signatures written to catch variants by targeting the technique rather than the specific variable names or literals in the sample.
+6. **Threat Summary** — a concise, shareable report with category, sophistication, most-dangerous capability, and immediate containment actions.
+
+## How it works
+
+The skill operates under a strict golden rule: **static analysis only — never execute the file**, not in a sandbox, not partially, not ever. It reasons about behavior by reading code, because running unknown malware can compromise the system, destroy evidence, or trigger anti-analysis behavior. Where a layer is encrypted with a key visible in the source, it generates a clean, standalone decryptor that implements only the cipher against the extracted ciphertext — never the malware itself — so every IOC is reported as a concrete, actionable value instead of an obfuscated placeholder.


### PR DESCRIPTION
## Summary

Adds the Malware Analyst listing to the CyberAgents Exchange.

**Author:** @tomabai
**Type:** skill

---

*Founding Contributor — migrated from the pre-launch repository.*