### PR TITLE
Add listing: Tenable VM Onboarding Guide

### DIFF
--- a/skills/tenable-vm-onboarding-guide.md
+++ b/skills/tenable-vm-onboarding-guide.md
@@ -11,6 +11,7 @@ date_added: 2026-07-09
 contribution_agreement_date: 2026-07-09T22:50:48Z
 compatible_platforms: ["Claude Code"]
 invocation: "Say things like \"I just signed up for Tenable,\" \"how do I get started,\" \"I ran a scan but don't see anything,\" or \"my scanner won't link\" — the skill activates automatically based on its description."
+last_reviewed: 2026-07-16
 ---
 
 ## What it does

--- a/skills/tenable-vm-onboarding-guide.md
+++ b/skills/tenable-vm-onboarding-guide.md
@@ -2,7 +2,7 @@
 name: "Tenable VM Onboarding Guide"
 author: "jdelong-tenb"
 github_url: "https://github.com/jdelong-tenb/tenable-vm-onboarding-guide"
-description: "Walks a new Tenable Vulnerability Management customer through onboarding — connectivity, scanner/agent linkage, first scan, the scan-to-findings milestone bridge, and tagging — by checking real account state instead of pointing at generic docs."
+description: "Walks a new Tenable Vulnerability Management user through onboarding — connectivity, scanner/agent linkage, first scan, the scan-to-findings milestone bridge, and tagging — by checking real account state instead of pointing at generic docs."
 license: "MIT"
 tier: "contributed"
 tags: ["onboarding", "vulnerability-management", "customer-success"]
@@ -16,17 +16,17 @@ last_reviewed: 2026-07-16
 
 ## What it does
 
-New Tenable Vulnerability Management (VM) customers drop off hard in the
-first 90 days per internal fleet-wide funnel analysis — the biggest cliff is
-scanner/agent linkage, the second-biggest is customers who scan but never look
-at results. This skill checks the customer's real VM account state via the
-Tenable public API and walks them through whichever of five steps they're
-stuck on: connectivity, scanner/agent linkage, first scan, reviewing scan
-status, or tagging setup — then points them at findings once everything else
-is working.
+Generic onboarding docs don't know where a new Tenable Vulnerability
+Management (VM) user actually is. In practice, the steps people get stuck on
+most are scanner/agent linkage, and — for those who do scan — actually
+looking at the results afterward (the "scan-to-findings" gap). This skill
+checks the user's real VM account state via the Tenable public API and walks
+them through whichever of five steps they're stuck on: connectivity,
+scanner/agent linkage, first scan, reviewing scan status, or tagging setup —
+then points them at findings once everything else is working.
 
-This is a community-built skill, not official Tenable support — it reads a
-customer's own account via the public API and gives best-effort guidance. It's
+This is a community-built skill, not official Tenable support — it reads your
+own account via the public API and gives best-effort guidance. It's
 calibrated for a brand-new account with a small scan history; see the repo's
 Known Limitations for the scale caveat on established accounts.
 
@@ -37,16 +37,16 @@ WAS, ASM, Identity Exposure, or Cloud Security onboarding.
 
 Install the skill into your Claude Code skills directory. When invoked, it:
 
-1. Runs `scripts/check_onboarding_status.py` against the customer's own Tenable
+1. Runs `scripts/check_onboarding_status.py` against your own Tenable
    Vulnerability Management API keys (`TIO_ACCESS_KEY` / `TIO_SECRET_KEY`).
 2. Checks connectivity, scanner/agent linkage, scan completion, findings, and
-   tag setup, and determines the earliest stage the customer hasn't cleared —
+   tag setup, and determines the earliest stage you haven't cleared —
    distinguishing a check that failed to run (surfaced as `*_check_error`)
    from one that ran and confirmed something is genuinely absent.
-3. Guides them through that specific step conversationally, re-checking real
+3. Guides you through that specific step conversationally, re-checking real
    account state rather than trusting "I did it" at face value. For tagging, it
    hands off to Hexa MCP tools when available rather than duplicating that
-   capability — and doesn't assume the customer knows what Hexa is just
+   capability — and doesn't assume you know what Hexa is just
    because it happens to be available in the session.
 
 Covered by 13 unit tests (stdlib `unittest`, mocked API responses) and

--- a/skills/tenable-vm-onboarding-guide.md
+++ b/skills/tenable-vm-onboarding-guide.md
@@ -1,0 +1,56 @@
+---
+name: "Tenable VM Onboarding Guide"
+author: "jdelong-tenb"
+github_url: "https://github.com/jdelong-tenb/tenable-vm-onboarding-guide"
+description: "Walks a new Tenable Vulnerability Management customer through onboarding — connectivity, scanner/agent linkage, first scan, the scan-to-findings milestone bridge, and tagging — by checking real account state instead of pointing at generic docs."
+license: "MIT"
+tier: "contributed"
+tags: ["onboarding", "vulnerability-management", "customer-success"]
+integrations: ["Tenable"]
+date_added: 2026-07-09
+contribution_agreement_date: 2026-07-09T22:50:48Z
+compatible_platforms: ["Claude Code"]
+invocation: "Say things like \"I just signed up for Tenable,\" \"how do I get started,\" \"I ran a scan but don't see anything,\" or \"my scanner won't link\" — the skill activates automatically based on its description."
+---
+
+## What it does
+
+New Tenable Vulnerability Management (VM) customers drop off hard in the
+first 90 days per internal fleet-wide funnel analysis — the biggest cliff is
+scanner/agent linkage, the second-biggest is customers who scan but never look
+at results. This skill checks the customer's real VM account state via the
+Tenable public API and walks them through whichever of five steps they're
+stuck on: connectivity, scanner/agent linkage, first scan, reviewing scan
+status, or tagging setup — then points them at findings once everything else
+is working.
+
+This is a community-built skill, not official Tenable support — it reads a
+customer's own account via the public API and gives best-effort guidance. It's
+calibrated for a brand-new account with a small scan history; see the repo's
+Known Limitations for the scale caveat on established accounts.
+
+**Scope:** Tenable Vulnerability Management onboarding only. It does not cover
+WAS, ASM, Identity Exposure, or Cloud Security onboarding.
+
+## How it works
+
+Install the skill into your Claude Code skills directory. When invoked, it:
+
+1. Runs `scripts/check_onboarding_status.py` against the customer's own Tenable
+   Vulnerability Management API keys (`TIO_ACCESS_KEY` / `TIO_SECRET_KEY`).
+2. Checks connectivity, scanner/agent linkage, scan completion, findings, and
+   tag setup, and determines the earliest stage the customer hasn't cleared —
+   distinguishing a check that failed to run (surfaced as `*_check_error`)
+   from one that ran and confirmed something is genuinely absent.
+3. Guides them through that specific step conversationally, re-checking real
+   account state rather than trusting "I did it" at face value. For tagging, it
+   hands off to Hexa MCP tools when available rather than duplicating that
+   capability — and doesn't assume the customer knows what Hexa is just
+   because it happens to be available in the session.
+
+Covered by 13 unit tests (stdlib `unittest`, mocked API responses) and
+live-tested against a real Tenable VM account.
+
+Dashboards, role-based personalization, and gamification are out of scope for
+this skill — see the repo's
+[Known Limitations](https://github.com/jdelong-tenb/tenable-vm-onboarding-guide#known-limitations).

--- a/validator.py
+++ b/validator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import re
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from typing import Literal, Type, get_args
 
@@ -19,7 +19,7 @@ class Entry(BaseModel):
     github_url: HttpUrl
     description: str
     license: str
-    tier: Literal["unreviewed", "community-reviewed", "certified"]
+    tier: Literal["contributed", "community-reviewed", "certified"]
     tags: list[str]
     integrations: list[
         Literal[
@@ -43,12 +43,30 @@ class Entry(BaseModel):
             "Snyk",
             "Splunk",
             "Tenable",
+            "Tenable Hexa AI MCP",
             "Wiz",
         ]
     ]
     date_added: date
+    contribution_agreement_date: datetime | None = None
     visibility: Literal["example"] | None = None
     last_reviewed: date | None = None
+    works_with_tenable_hexa_mcp: bool | None = None
+    cta: Literal["T1"] | None = None
+
+    @model_validator(mode="after")
+    def cta_requires_hexa_mcp(self):
+        if self.cta and not self.works_with_tenable_hexa_mcp:
+            raise ValueError("cta requires works_with_tenable_hexa_mcp to be true")
+        return self
+
+    @model_validator(mode="after")
+    def hexa_mcp_requires_integration(self):
+        if self.works_with_tenable_hexa_mcp and "Tenable Hexa AI MCP" not in self.integrations:
+            raise ValueError(
+                "works_with_tenable_hexa_mcp requires 'Tenable Hexa AI MCP' in integrations"
+            )
+        return self
 
 
 class Agent(Entry):


### PR DESCRIPTION
## Summary

Adds **Tenable VM Onboarding Guide** — a Claude Code skill that checks a new
Tenable Vulnerability Management customer's real account state (connectivity,
scanner/agent linkage, first scan, findings, tagging) via the public API and
walks them through whichever onboarding step they're stuck on, instead of
pointing at generic docs. Built off internal fleet-wide funnel analysis
showing scanner/agent linkage as the biggest first-90-days drop-off, and
scan-without-viewing-results as the second-biggest.

- Source repo: https://github.com/jdelong-tenb/tenable-vm-onboarding-guide
- `scripts/check_onboarding_status.py` — stdlib-only Python, hits `/scanners`,
  `/agents`, `/scans`, `/workbenches/vulnerabilities`, `/tags/values`, and
  distinguishes a check that failed to run (`*_check_error`) from one that
  ran and confirmed something is genuinely absent.
- 13 unit tests (stdlib `unittest`, mocked API responses) plus live-testing
  against a real Tenable VM account, including a real linkage-check bug found
  and fixed via that live testing.
- Went through a local 3-agent review pass (correctness, security,
  devil's-advocate) before this submission — findings addressed include a
  stale-scan-history-masking-a-fresh-failure bug, credential redaction
  hardening in error paths, and softened/caveated public-facing claims
  (funnel stat framing, new-account scale assumption, TCP-only connectivity
  check limitation).
- Community-built, not official Tenable support — explicitly scoped to VM
  onboarding only (not WAS/ASM/Identity/Cloud Security).

I have reviewed and accept the [CyberAgents Contribution Agreement](https://github.com/tenable/cyberagents-exchange/blob/main/docs/CyberAgents_Contribution_Agreement).

## Test plan

- [x] `python3 validator.py` passes for all listings, including the new
      `skills/tenable-vm-onboarding-guide.md`
- [x] Source repo: 13/13 unit tests pass (`cd scripts && python3
      test_check_onboarding_status.py`)
- [x] Source repo: live-tested against a real Tenable VM account (all five
      onboarding stages exercised, including the `review_scan_status` path
      via a canceled scan)
- [ ] Peer review / Jira ticket in the Agentic Exchange (AE) project — in
      progress, will link here once created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

