### PR TITLE
Add listing: The Hounds — navi-agents

### DIFF
--- a/playbooks/the-hounds-navi-agents.md
+++ b/playbooks/the-hounds-navi-agents.md
@@ -5,7 +5,7 @@ author: "packetchaos"
 github_url: "https://github.com/packetchaos/the-hounds-repo"
 description: "The executable harness for The Hounds — a local console that runs the exposure-management agent pack over Tenable navi."
 license: "MIT"
-tier: "unreviewed"
+tier: "contributed"
 tags: [tenable, exposure-management, navi, playbook, python, console, vulnerability-management]
 integrations: [Tenable, Anthropic]
 agents_used:
@@ -64,6 +64,7 @@ agents_used:
     role: "Enforces the AI Contract governance policy."
     type: "info"
 date_added: 2026-07-15
+contribution_agreement_date: 2026-07-15T18:28:19Z
 ---
 
 The Hounds — navi-agents is the executable harness for the pack: a local console

--- a/playbooks/the-hounds-navi-agents.md
+++ b/playbooks/the-hounds-navi-agents.md
@@ -1,0 +1,90 @@
+---
+playbook_type: "standard"
+name: "The Hounds — navi-agents"
+author: "packetchaos"
+github_url: "https://github.com/packetchaos/the-hounds-repo"
+description: "The executable harness for The Hounds — a local console that runs the exposure-management agent pack over Tenable navi."
+license: "MIT"
+tier: "unreviewed"
+tags: [tenable, exposure-management, navi, playbook, python, console, vulnerability-management]
+integrations: [Tenable, Anthropic]
+agents_used:
+  - name: "Laelaps"
+    role: "Finds and tags CISA KEV (known exploited) exposure."
+    type: "info"
+  - name: "Certania"
+    role: "Tracks certificate expiry and weak crypto."
+    type: "info"
+  - name: "Heimdall"
+    role: "Assesses post-quantum readiness."
+    type: "info"
+  - name: "Fenrir"
+    role: "Chains signals into ranked attack paths (foothold to crown jewel)."
+    type: "info"
+  - name: "Cerberus"
+    role: "Confidence-scored IoT / OT / embedded device discovery."
+    type: "info"
+  - name: "Pythia"
+    role: "Discovers and governs AI/ML inventory across five sources."
+    type: "info"
+  - name: "Atlas"
+    role: "Establishes asset ownership."
+    type: "info"
+  - name: "Mimir"
+    role: "Software inventory."
+    type: "info"
+  - name: "Charon"
+    role: "Flags end-of-life / unsupported software."
+    type: "info"
+  - name: "Anubis"
+    role: "Calibrates Asset Criticality Rating (ACR)."
+    type: "info"
+  - name: "Chronos"
+    role: "Scan health monitoring."
+    type: "info"
+  - name: "Sirius"
+    role: "Agent group analysis."
+    type: "info"
+  - name: "Garmr"
+    role: "Tag removal and cleanup."
+    type: "info"
+  - name: "Orthrus"
+    role: "Maps findings to MITRE ATT&CK."
+    type: "info"
+  - name: "Argus"
+    role: "Custom application discovery."
+    type: "info"
+  - name: "Argos"
+    role: "Single-asset deep-dive."
+    type: "info"
+  - name: "Sphinx"
+    role: "'On the Scent' environment overview."
+    type: "info"
+  - name: "Covenant"
+    role: "Enforces the AI Contract governance policy."
+    type: "info"
+date_added: 2026-07-15
+---
+
+The Hounds — navi-agents is the executable harness for the pack: a local console
+(`navi-agents/`) that runs the exposure-management hounds over
+[Tenable **navi**](https://github.com/packetchaos/navi) (`navi.db` + the Tenable API) and
+surfaces the results in the browser. It runs on a stock Python install — the default server
+needs no third-party packages.
+
+## What it does
+
+It executes the same pack of specialists as a program rather than a skill: CISA KEV
+(Laelaps), attack paths (Fenrir), IoT/OT (Cerberus), AI inventory (Pythia), certificates
+(Certania), EOL software (Charon), ACR calibration (Anubis), and the rest. Each hound
+hunts one kind of exposure and proposes navi tag/ACR writes for human approval; writes are
+disabled by default (`NAVI_ALLOW_WRITES=0`).
+
+## How it works
+
+Launch with `python3 run.py` (zero-dependency stdlib server, or optional FastAPI/Flask).
+On first run it builds a bundled sample database so you can evaluate it with no setup; for
+production, point `NAVI_DB_PATH` at navi's real `navi.db`. The `core/` engine provides the
+shared detection, discovery, health, MITRE, and EOL logic, and `core/agents/` holds the
+individual hound implementations. Every write stays grounded in real navi data and gated
+behind explicit confirmation.

--- a/playbooks/the-hounds-navi-agents.md
+++ b/playbooks/the-hounds-navi-agents.md
@@ -64,6 +64,7 @@ agents_used:
     role: "Enforces the AI Contract governance policy."
     type: "info"
 date_added: 2026-07-15
+last_reviewed: 2026-07-17
 contribution_agreement_date: 2026-07-15T18:28:19Z
 ---
 

--- a/validator.py
+++ b/validator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import re
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from typing import Literal, Type, get_args
 
@@ -19,7 +19,7 @@ class Entry(BaseModel):
     github_url: HttpUrl
     description: str
     license: str
-    tier: Literal["unreviewed", "community-reviewed", "certified"]
+    tier: Literal["contributed", "community-reviewed", "certified"]
     tags: list[str]
     integrations: list[
         Literal[
@@ -43,12 +43,30 @@ class Entry(BaseModel):
             "Snyk",
             "Splunk",
             "Tenable",
+            "Tenable Hexa AI MCP",
             "Wiz",
         ]
     ]
     date_added: date
+    contribution_agreement_date: datetime | None = None
     visibility: Literal["example"] | None = None
     last_reviewed: date | None = None
+    works_with_tenable_hexa_mcp: bool | None = None
+    cta: Literal["T1"] | None = None
+
+    @model_validator(mode="after")
+    def cta_requires_hexa_mcp(self):
+        if self.cta and not self.works_with_tenable_hexa_mcp:
+            raise ValueError("cta requires works_with_tenable_hexa_mcp to be true")
+        return self
+
+    @model_validator(mode="after")
+    def hexa_mcp_requires_integration(self):
+        if self.works_with_tenable_hexa_mcp and "Tenable Hexa AI MCP" not in self.integrations:
+            raise ValueError(
+                "works_with_tenable_hexa_mcp requires 'Tenable Hexa AI MCP' in integrations"
+            )
+        return self
 
 
 class Agent(Entry):


### PR DESCRIPTION
## New Listing: The Hounds — navi-agents

**Repository:** see `github_url` in the listing frontmatter
**Type directory:** `playbooks/`

### Checklist
- [x] I have reviewed and accept the CyberAgents Exchange Contribution Agreement
- [x] Code is in a personal GitHub repo (packetchaos)
- [x] Repo has a README
- [x] Repo has an open source license
- [x] Listing file passes validator.py schema validation
- [x] Listing placed in correct directory (playbooks/)
- [x] Filename is a valid slug (the-hounds-navi-agents.md)