### PR TITLE
Add listing: BOD 26-04 Risk Tiering

### DIFF
--- a/skills/bod-26-04-risk-tiering.md
+++ b/skills/bod-26-04-risk-tiering.md
@@ -1,0 +1,32 @@
+---
+name: "BOD 26-04 Risk Tiering"
+author: "itschrisyo"
+github_url: "https://github.com/itschrisyo/bod-26-04-risk-tiering"
+description: "Computes CISA BOD 26-04 remediation tiers for Tenable vulnerability findings using the directive's 4-variable model."
+license: "MIT"
+tier: "unreviewed"
+tags: ["bod-26-04", "cisa", "vulnerability-management", "compliance", "risk-tiering", "kev", "tenable"]
+integrations: ["Tenable"]
+date_added: 2026-07-16
+compatible_platforms: ["Claude Code"]
+invocation: "/bod-26-04-risk-tiering"
+---
+
+This skill automates CISA BOD 26-04 compliance for federal agencies and organizations managing Tenable vulnerability data. It computes remediation tiers using the directive's four-variable risk model: Publicly Exposed × In KEV × Automatable × Technical Impact.
+
+## What it does
+
+Takes Tenable One/TVM vulnerability findings and produces BOD 26-04-compliant remediation tiers with specific deadlines:
+- **3-day + forensic triage** (actively exploited KEV on public-facing assets)
+- **3-day** (high-risk KEV)
+- **14-day** (medium-risk KEV)
+- **60-day** (lower-risk)
+- **Fix-on-upgrade** (maintenance window)
+
+Pulls data directly from Tenable via Hexa MCP, enriches with CISA Vulnrichment for automation/impact assessments, applies Table 1 logic, and generates action queues with countdown timers from first-seen dates.
+
+## How it works
+
+The skill extracts KEV dates from Tenable Workbench, handles Windows patch bundles by extracting individual CVEs, fetches CISA SSVC assessments via Vulnrichment API, computes tiers using BOD 26-04's 16-row lookup table, and outputs multiple report formats (JSON for automation, CSV for leadership, text for humans). Includes forensic triage flags for potential active breaches and coverage statistics showing CISA data availability.
+
+Production-tested on 500 assets with 539 KEV vulnerabilities, achieving 64.3% CISA coverage. Zero external dependencies (Python stdlib only). 21 unit tests covering all Table 1 rows and edge cases.

--- a/skills/bod-26-04-risk-tiering.md
+++ b/skills/bod-26-04-risk-tiering.md
@@ -4,10 +4,11 @@ author: "itschrisyo"
 github_url: "https://github.com/itschrisyo/bod-26-04-risk-tiering"
 description: "Computes CISA BOD 26-04 remediation tiers for Tenable vulnerability findings using the directive's 4-variable model."
 license: "MIT"
-tier: "unreviewed"
+tier: "contributed"
 tags: ["bod-26-04", "cisa", "vulnerability-management", "compliance", "risk-tiering", "kev", "tenable"]
 integrations: ["Tenable"]
 date_added: 2026-07-16
+contribution_agreement_date: 2026-07-16T16:40:40Z
 compatible_platforms: ["Claude Code"]
 invocation: "/bod-26-04-risk-tiering"
 ---

--- a/skills/bod-26-04-risk-tiering.md
+++ b/skills/bod-26-04-risk-tiering.md
@@ -6,9 +6,11 @@ description: "Computes CISA BOD 26-04 remediation tiers for Tenable vulnerabilit
 license: "MIT"
 tier: "contributed"
 tags: ["bod-26-04", "cisa", "vulnerability-management", "compliance", "risk-tiering", "kev", "tenable"]
-integrations: ["Tenable"]
+integrations: ["Tenable", "Tenable Hexa AI MCP"]
 date_added: 2026-07-16
 contribution_agreement_date: 2026-07-16T16:40:40Z
+works_with_tenable_hexa_mcp: true
+cta: "T1"
 compatible_platforms: ["Claude Code"]
 invocation: "/bod-26-04-risk-tiering"
 ---

--- a/skills/bod-26-04-risk-tiering.md
+++ b/skills/bod-26-04-risk-tiering.md
@@ -11,6 +11,7 @@ date_added: 2026-07-16
 contribution_agreement_date: 2026-07-16T16:40:40Z
 works_with_tenable_hexa_mcp: true
 cta: "T1"
+last_reviewed: 2026-07-26
 compatible_platforms: ["Claude Code"]
 invocation: "/bod-26-04-risk-tiering"
 ---

--- a/validator.py
+++ b/validator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import re
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from typing import Literal, Type, get_args
 
@@ -19,7 +19,7 @@ class Entry(BaseModel):
     github_url: HttpUrl
     description: str
     license: str
-    tier: Literal["unreviewed", "community-reviewed", "certified"]
+    tier: Literal["contributed", "community-reviewed", "certified"]
     tags: list[str]
     integrations: list[
         Literal[
@@ -43,12 +43,22 @@ class Entry(BaseModel):
             "Snyk",
             "Splunk",
             "Tenable",
+            "Tenable Hexa AI MCP",
             "Wiz",
         ]
     ]
     date_added: date
+    contribution_agreement_date: datetime | None = None
     visibility: Literal["example"] | None = None
     last_reviewed: date | None = None
+    works_with_tenable_hexa_mcp: bool | None = None
+    cta: Literal["T1"] | None = None
+
+    @model_validator(mode="after")
+    def cta_requires_hexa_mcp(self):
+        if self.cta and not self.works_with_tenable_hexa_mcp:
+            raise ValueError("cta requires works_with_tenable_hexa_mcp to be true")
+        return self
 
 
 class Agent(Entry):

--- a/validator.py
+++ b/validator.py
@@ -60,6 +60,14 @@ class Entry(BaseModel):
             raise ValueError("cta requires works_with_tenable_hexa_mcp to be true")
         return self
 
+    @model_validator(mode="after")
+    def hexa_mcp_requires_integration(self):
+        if self.works_with_tenable_hexa_mcp and "Tenable Hexa AI MCP" not in self.integrations:
+            raise ValueError(
+                "works_with_tenable_hexa_mcp requires 'Tenable Hexa AI MCP' in integrations"
+            )
+        return self
+
 
 class Agent(Entry):
     """Agent Exchange Entry"""


### PR DESCRIPTION
## New Listing: BOD 26-04 Risk Tiering

**Repository:** https://github.com/itschrisyo/bod-26-04-risk-tiering
**Description:** Computes CISA BOD 26-04 remediation tiers for Tenable vulnerability findings using the directive's 4-variable model.

### Checklist
- [x] I have reviewed and accept the [CyberAgents Exchange Contribution Agreement](https://github.com/tenable/cyberagents-exchange/blob/main/docs/CyberAgents_Contribution_Agreement)
- [x] Agent/playbook code is in a personal GitHub repo
- [x] Repo has a README
- [x] Repo has an open source license (MIT)
- [x] Listing file passes schema validation
- [x] Listing placed in correct directory (skills/)
- [x] Filename is a valid slug (bod-26-04-risk-tiering.md)