### PR TITLE
Backfill works_with_tenable_hexa_mcp on existing Hexa MCP listings

### DIFF
--- a/agents/nessus-agent-companion.md
+++ b/agents/nessus-agent-companion.md
@@ -6,8 +6,10 @@ description: "An autonomous AI agent that monitors the health of Tenable Nessus 
 license: "MIT"
 tier: "contributed"
 tags: ["monitoring", "nessus-agents", "slack", "vulnerability-management", "tenable", "ai-agent", "security"]
-integrations: ["Tenable"]
+integrations: ["Tenable", "Tenable Hexa AI MCP"]
 date_added: 2026-06-15
+works_with_tenable_hexa_mcp: true
+cta: "T1"
 ---
 
 Nessus Agent Companion is a focused, single-purpose AI agent for Tenable Nessus Agent health monitoring and maintenance. It connects to Tenable Vulnerability Management via the Tenable MCP server, monitors your agent fleet on a scheduled heartbeat, and uses an LLM to analyze changes, correlate risks, and communicate findings to your team in Slack.

--- a/mcp-servers/tenable-mcp-mssp.md
+++ b/mcp-servers/tenable-mcp-mssp.md
@@ -6,8 +6,10 @@ description: "An MCP server for orchestrating Tenable MSSP child container workf
 license: "MIT"
 tier: "contributed"
 tags: ["mssp", "vulnerability-management", "tenable-vm", "exposure-management", "tenable-one"]
-integrations: ["Tenable"]
+integrations: ["Tenable", "Tenable Hexa AI MCP"]
 date_added: 2026-06-23
+works_with_tenable_hexa_mcp: true
+cta: "T1"
 transport: "stdio"
 runtime: "python"
 auth_method: "none"

--- a/skills/export-nessus-template.md
+++ b/skills/export-nessus-template.md
@@ -6,8 +6,10 @@ description: "Export scans and policies from Nessus, Tenable.io, or Tenable.sc t
 license: "MIT"
 tier: "contributed"
 tags: ["tenable", "nessus", "vulnerability-scanning", "migration", "scan-automation", "security"]
-integrations: ["Tenable"]
+integrations: ["Tenable", "Tenable Hexa AI MCP"]
 date_added: 2026-07-07
+works_with_tenable_hexa_mcp: true
+cta: "T1"
 compatible_platforms: ["Claude Code"]
 invocation: "/export-nessus-template"
 ---

--- a/skills/remediation-priority-impact-agent.md
+++ b/skills/remediation-priority-impact-agent.md
@@ -6,8 +6,10 @@ description: "Prioritizes daily vulnerability fixes using Tenable exposure data,
 license: "MIT"
 tier: "contributed"
 tags: ["vulnerability-management", "exposure-management", "remediation-prioritization", "cisa-kev", "mitre-attack", "attack-path-analysis"]
-integrations: ["Tenable"]
+integrations: ["Tenable", "Tenable Hexa AI MCP"]
 date_added: 2026-06-18
+works_with_tenable_hexa_mcp: true
+cta: "T1"
 compatible_platforms: ["Claude Code"]
 invocation: "/fix-today"
 ---

--- a/skills/tenable-quick-wins-executive-dashboard.md
+++ b/skills/tenable-quick-wins-executive-dashboard.md
@@ -6,8 +6,10 @@ description: "Executive dashboard that prioritizes remediation to cut Tenable On
 license: "MIT"
 tier: "contributed"
 tags: ["tenable-one", "exposure-management", "executive-dashboard", "quick-wins", "vulnerability-prioritization", "ciso"]
-integrations: ["Tenable", "Anthropic"]
+integrations: ["Tenable", "Tenable Hexa AI MCP", "Anthropic"]
 date_added: 2026-06-30
+works_with_tenable_hexa_mcp: true
+cta: "T1"
 compatible_platforms: ["Claude Desktop"]
 invocation: "/tenable-quick-wins-dashboard"
 ---

--- a/skills/tenable-user-health.md
+++ b/skills/tenable-user-health.md
@@ -6,8 +6,10 @@ description: "Audits Tenable user activity, authentication security, and maps fi
 license: "MIT"
 tier: "contributed"
 tags: ["tenable", "compliance", "user-management", "authentication", "audit", "security"]
-integrations: ["Tenable"]
+integrations: ["Tenable", "Tenable Hexa AI MCP"]
 date_added: 2026-07-08
+works_with_tenable_hexa_mcp: true
+cta: "T1"
 compatible_platforms: ["Claude Code"]
 invocation: "/tenable-user-health"
 ---

--- a/skills/threat-intel-daily.md
+++ b/skills/threat-intel-daily.md
@@ -6,8 +6,10 @@ description: "A daily, fully-sourced cyber threat intelligence briefing for CISO
 license: "MIT"
 tier: "contributed"
 tags: ["threat-intelligence", "ciso", "cti", "vulnerability-management", "tenable", "security-automation"]
-integrations: ["Tenable", "Anthropic"]
+integrations: ["Tenable", "Tenable Hexa AI MCP", "Anthropic"]
 date_added: 2026-06-18
+works_with_tenable_hexa_mcp: true
+cta: "T1"
 compatible_platforms: ["Claude Code"]
 invocation: "/threat-intel-daily"
 ---

--- a/validator.py
+++ b/validator.py
@@ -60,6 +60,14 @@ class Entry(BaseModel):
             raise ValueError("cta requires works_with_tenable_hexa_mcp to be true")
         return self
 
+    @model_validator(mode="after")
+    def hexa_mcp_requires_integration(self):
+        if self.works_with_tenable_hexa_mcp and "Tenable Hexa AI MCP" not in self.integrations:
+            raise ValueError(
+                "works_with_tenable_hexa_mcp requires 'Tenable Hexa AI MCP' in integrations"
+            )
+        return self
+
 
 class Agent(Entry):
     """Agent Exchange Entry"""

--- a/validator.py
+++ b/validator.py
@@ -43,6 +43,7 @@ class Entry(BaseModel):
             "Snyk",
             "Splunk",
             "Tenable",
+            "Tenable Hexa AI MCP",
             "Wiz",
         ]
     ]


### PR DESCRIPTION
## Summary

- Adds `"Tenable Hexa AI MCP"` to the validator integrations vocabulary
- Backfills `works_with_tenable_hexa_mcp: true`, `cta: "T1"`, and `"Tenable Hexa AI MCP"` integration on 7 merged listings that use the Tenable Hexa MCP server:
  - `mcp-servers/tenable-mcp-mssp.md`
  - `skills/remediation-priority-impact-agent.md`
  - `skills/export-nessus-template.md`
  - `skills/tenable-quick-wins-executive-dashboard.md`
  - `agents/nessus-agent-companion.md`
  - `skills/threat-intel-daily.md`
  - `skills/tenable-user-health.md`

Also pushed matching changes to 3 open PRs (#76, #62, #64) via maintainer push.

## Test plan

- [x] `validator.py` passes on all listings in this branch