### PR TITLE
Document squash-and-merge policy in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,6 +225,10 @@ Reviewers will also verify:
 
 If anything needs attention, you'll receive specific feedback as a review comment on your PR.
 
+### How PRs Are Merged
+
+All pull requests are merged using **squash and merge** — the entire PR is combined into a single commit on `main`. Merge commits and rebase merges are disabled, so squash is the only option. The squash commit uses your PR title and description, so please keep them clear and descriptive. The source branch is deleted automatically after the merge.
+
 ## Things That Will Get Your Submission Rejected
 
 Regardless of how well-formatted your listing is, submissions are rejected outright if they involve:


### PR DESCRIPTION
## Summary

Documents the repository's merge policy in `CONTRIBUTING.md`.

Adds a "How PRs Are Merged" section under *What Happens After You Submit* explaining that all PRs use **squash and merge**:

- Squash is the only merge method (merge commits and rebase merges are disabled in repo settings)
- The squash commit uses the PR title and description
- The source branch is auto-deleted after merge

The corresponding GitHub repo settings have already been applied to enforce this.