### PR TITLE
Add listing: Chokepoint Finder MCP Server

### DIFF
--- a/mcp-servers/chokepoint-finder-mcp.md
+++ b/mcp-servers/chokepoint-finder-mcp.md
@@ -1,4 +1,5 @@
 ---
+last_reviewed: 2026-08-05
 name: "Chokepoint Finder MCP Server"
 author: "tarhou"
 github_url: "https://github.com/tarhou/chokepoint-finder-mcp"

--- a/mcp-servers/chokepoint-finder-mcp.md
+++ b/mcp-servers/chokepoint-finder-mcp.md
@@ -1,0 +1,89 @@
+---
+name: "Chokepoint Finder MCP Server"
+author: "tarhou"
+github_url: "https://github.com/tarhou/chokepoint-finder-mcp"
+description: "A FastMCP server that collapses findings into shared fixes, ranks them by marginal risk coverage, gates unsafe changes on fail-closed evidence, and verifies outcomes against the authoritative source."
+license: "MIT"
+tier: "contributed"
+tags: ["vuln-management", "exposure-management", "remediation", "prioritization", "attack-path-analysis", "set-cover", "fail-closed", "mcp-server"]
+integrations: ["AWS", "Tenable"]
+date_added: 2026-08-05
+contribution_agreement_date: 2026-08-05T02:04:27Z
+works_with_tenable_hexa_mcp: false
+compatible_clients: ["Claude Code", "Claude Desktop"]
+transport: "stdio"
+runtime: "python"
+auth_method: "api-key"
+tools_exposed:
+  - name: "chokepoint_setup"
+    description: "Reports what is configured, tests each connection, and names the exact missing variable rather than failing vaguely."
+  - name: "chokepoint_ingest"
+    description: "Loads findings, assets and attack paths from a source and builds the engine baseline."
+  - name: "chokepoint_rank"
+    description: "Greedy weighted max-coverage over synthesized actions; returns the ordered shortlist with marginal risk."
+  - name: "chokepoint_preflight"
+    description: "Evidence gates before acting: EDR silence, change freeze, and blast radius."
+  - name: "chokepoint_supply_evidence"
+    description: "Relays gate evidence in from an MCP server you already have connected, with provenance retained."
+  - name: "chokepoint_payload"
+    description: "Ticket-ready remediation payload for a chokepoint: summary, justification, targets and rollback."
+  - name: "chokepoint_plan"
+    description: "Typed, ordered execution workflow with per-site waves and a canonical SHA-256 plan hash."
+  - name: "chokepoint_mark_executed"
+    description: "Records that approved steps were executed elsewhere, bound to the plan hash, wave and a one-time receipt."
+  - name: "chokepoint_verify"
+    description: "Re-queries the authoritative source and diffs against the baseline, returning a structured proof receipt."
+  - name: "chokepoint_demo"
+    description: "Runs the whole wave-aware loop on a deterministic simulated estate with no credentials."
+resources_exposed: []
+prompts_exposed: []
+---
+
+The engine behind the Chokepoint Finder method, exposed as ten typed MCP tools. It runs
+end to end with **zero credentials** against a deterministic simulated estate, so the
+mechanics can be inspected before any real tenant is connected.
+
+## What it does
+
+Most tooling ranks findings individually. That is the wrong unit of work: one patch
+rolled out fleet-wide, one base image rebuilt, one IAM role scoped, or one security
+group closed retires hundreds of findings at once. This server groups findings by the
+fix they share, then solves for the shortest ordered list of actions that removes the
+most weighted risk — reporting, for each action, what it retires *given everything above
+it is already done*.
+
+It also carries the parts that usually get hand-waved: pre-flight refusal on evidence,
+approval binding, and verification against the source of truth rather than against its
+own memory of what it asked for.
+
+## How it works
+
+**Ranking.** Greedy weighted maximum coverage over an action-to-findings coverage
+matrix. Marginal value means overlap is credited exactly once, so coverage sums to the
+total instead of past it. Under a pure cardinality constraint this is the classical
+greedy carrying the (1 − 1/e) guarantee; the README states plainly which configuration
+options preserve that bound and which are heuristics that forfeit it.
+
+**Fail-closed evidence.** Gates read typed evidence carrying source, collection time and
+completeness. Anything unconfigured, failed, partial, truncated or stale resolves to
+`UNKNOWN`, and `UNKNOWN` produces `HOLD`. An empty result from a healthy feed is
+`ABSENT` — a genuinely different state — and does clear the gate. Misconfiguration can
+therefore only make the server more cautious, never less.
+
+**Composable evidence.** The server holds no EDR, SIEM or ITSM credentials and never
+will. Telemetry arrives through `chokepoint_supply_evidence`, relayed from MCP servers
+the operator already runs, with provenance preserved so a relayed third-party detection
+is never filed as if the server had observed it directly. Because a relaying agent could
+in principle understate risk, evidence that would *widen* permission is surfaced to a
+human with a payload digest and requires a recent one-time confirmation, while evidence
+that can only make the outcome more cautious is accepted directly.
+
+**Verification.** `chokepoint_verify` re-queries the authoritative source and diffs
+against the recorded baseline, returning counts for retired, reappeared and remaining
+findings. Simulated runs are labelled as such and can never be presented as closure
+evidence for a real change record.
+
+Transport is stdio by default; an HTTP mode exists for local development and refuses to
+bind anywhere but loopback. Tenable and AWS collectors are read-only. The safety
+properties above are asserted by the test suite rather than promised in prose, including
+tests that inject drift and assert the checks fail.


### PR DESCRIPTION
I have reviewed and accept the [CyberAgents Contribution Agreement](https://github.com/tenable/cyberagents-exchange/blob/main/docs/CyberAgents_Contribution_Agreement).

## Summary

Adds `mcp-servers/chokepoint-finder-mcp.md`, a listing for the **Chokepoint Finder MCP
Server** — a FastMCP server exposing ten typed tools that group vulnerability findings
by the fix they share, rank the shortest set of actions that retires the most weighted
risk, gate unsafe changes on fail-closed evidence, and verify outcomes against the
authoritative source.

It runs end to end with **zero credentials** against a deterministic simulated estate
(`uv run python -m chokepoint_finder.demo`), so a reviewer can inspect the mechanics
without connecting a tenant.

Two properties worth calling out for review:

- **Fail-closed evidence.** Gates read typed evidence carrying source, collection time
  and completeness. Anything unconfigured, failed, partial, truncated or stale resolves
  to `UNKNOWN`, and `UNKNOWN` produces `HOLD`. Misconfiguration can only ever make the
  server more cautious, never less.
- **No credentials for third-party telemetry.** The server holds no EDR, SIEM or ITSM
  credentials. That evidence is relayed in from MCP servers the operator already runs,
  with provenance preserved so a relayed detection is never recorded as a direct
  observation.

Outbound calls are limited to the Tenable and AWS read-only collectors, and are
documented in the README. Transport is stdio by default; the HTTP mode is local
development only and refuses to bind to anything but loopback.

## Checklist

- Repository is public, active, and owned by a personal account (`tarhou`)
- `LICENSE` present — MIT, and `pyproject.toml` declares MIT, so nothing contradicts
- No secrets in git history (scanned with `gitleaks`, full history, clean)
- README covers purpose, prerequisites, how to run, outputs, and known limitations
- `runtime: python` matches `pyproject.toml`; the `mcpServers` command
  (`chokepoint-mcp`) is a real `[project.scripts]` entry point
- `transport: stdio` is the actual default in `server.py`
- All ten `tools_exposed` entries exist in the server
- Exactly one new file, in `mcp-servers/`
- `uv run ./validator.py` passes locally
