### PR TITLE
Add listing: AI Secret Scanner

### DIFF
--- a/skills/ai-secret-scanner.md
+++ b/skills/ai-secret-scanner.md
@@ -1,0 +1,36 @@
+---
+name: "AI Secret Scanner"
+author: "SDSicuritech"
+github_url: "https://github.com/SDSicuritech/TenableAITokenSearch"
+description: "Scans authorized web apps for exposed AI and cloud API keys in client-delivered HTML and JavaScript."
+license: "MIT"
+tier: "contributed"
+tags: ["secrets-detection", "api-keys", "appsec", "exposure-management", "vulnerability-assessment"]
+integrations: ["Anthropic", "AWS"]
+date_added: 2026-08-05
+contribution_agreement_date: 2026-08-05T19:02:31Z
+compatible_platforms: ["Claude Code"]
+invocation: "/ai-secret-scanner"
+---
+
+Front-end code routinely ships provider credentials to the browser. This skill
+finds those exposures across assets you own and reports them in a form that is
+safe to store and act on.
+
+## What it does
+
+Fetches each authorized target's HTML and linked JavaScript, then matches
+credential shapes for OpenAI, Anthropic, Google/Gemini, Hugging Face, AWS access
+key IDs, Stripe live keys, GitHub tokens, Slack bot tokens, JWTs, and generic
+`api_key = "..."` assignments. Results land in a spreadsheet with source asset,
+key type, masked value, fingerprint, and a remediation note.
+
+## How it works
+
+Scanning is gated on an explicit `--scope` host allowlist — the skill refuses to
+run without one and skips any target or linked script outside it. Findings are
+never written in plaintext: each becomes a short non-sensitive prefix, a
+length-preserving mask (`sk-ant******(len=53)`), and a truncated SHA-256
+fingerprint that lets you correlate the same leaked key across assets. TLS
+verification stays on unless explicitly disabled. Detection only — it offers no
+way to test whether a discovered key is live.


### PR DESCRIPTION
## New Listing: AI Secret Scanner

**Repository:** https://github.com/SDSicuritech/TenableAITokenSearch
**Description:** Scans authorized web apps for exposed AI and cloud API keys in client-delivered HTML and JavaScript.

I have reviewed and accept the [CyberAgents Contribution Agreement](https://github.com/tenable/cyberagents-exchange/blob/main/docs/CyberAgents_Contribution_Agreement).

### Checklist
- [x] I have reviewed and accept the [CyberAgents Exchange Contribution Agreement](https://github.com/tenable/cyberagents-exchange/blob/main/docs/CyberAgents_Contribution_Agreement)
- [x] Skill code is in a personal GitHub repo (public, non-EMU account)
- [x] Repo has a README covering purpose, prerequisites, how to run, outputs, and limitations
- [x] Repo has an open source license (MIT)
- [x] Listing file passes schema validation (`validator.py` run locally, exit 0)
- [x] Listing placed in correct directory (`skills/`)
- [x] Filename is a valid slug (`ai-secret-scanner.md`)
- [x] No secrets in git history (only test fixtures and the AWS documentation example key)

### Notes
Detection-only and defensive by design: scanning is gated on an explicit `--scope`
host allowlist and refuses to run without one, findings are masked and
fingerprinted rather than stored in plaintext, TLS verification is on by default,
and the tool provides no capability to validate whether a discovered key is live.