### PR TITLE
Add listing: Evidence-Backed Vulnerability Investigator

### DIFF
--- a/agents/evidence-backed-vulnerability-investigator.md
+++ b/agents/evidence-backed-vulnerability-investigator.md
@@ -1,4 +1,5 @@
 ---
+last_reviewed: 2026-08-05
 name: "Evidence-Backed Vulnerability Investigator"
 author: "infosecloudninja007"
 github_url: "https://github.com/infosecloudninja007/evidence-vulnerability-investigator"

--- a/agents/evidence-backed-vulnerability-investigator.md
+++ b/agents/evidence-backed-vulnerability-investigator.md
@@ -1,0 +1,22 @@
+---
+name: "Evidence-Backed Vulnerability Investigator"
+author: "infosecloudninja007"
+github_url: "https://github.com/infosecloudninja007/evidence-vulnerability-investigator"
+description: "Streamlit prototype that matches vulnerability scanner findings against local advisory evidence and asks Claude for a structured, evidence-grounded disposition recommendation."
+license: "MIT"
+tier: "contributed"
+tags: ["vulnerability-management", "streamlit", "claude", "evidence-based", "security-analyst-workflow", "disposition-triage"]
+integrations: ["Anthropic"]
+date_added: 2026-08-05
+contribution_agreement_date: 2026-08-05T20:15:13Z
+---
+
+Evidence-Backed Vulnerability Investigator is a local Streamlit prototype that helps a security analyst investigate vulnerability scanner findings. It compares each finding against local Markdown vendor advisories, then asks Claude for a structured, evidence-grounded disposition recommendation — the analyst always makes the final call.
+
+## What it does
+
+Loads findings from CSV/JSON (or bundled samples), deterministically matches them against local advisory evidence (exact CVE/plugin-ID match, product/vendor/version overlap, keyword scoring — no embeddings), and calls Claude to recommend one of four dispositions: REMEDIATE, RECAST_MITIGATED, RECAST_FALSE_POSITIVE, or MANUAL_REVIEW. The analyst reviews, approves/rejects/overrides the recommendation, then saves and exports the investigation (JSON/Markdown).
+
+## How it works
+
+A thin Streamlit UI sits over independently unit-tested, pure-Python modules (config, findings, advisories, matching, prompts, claude_client, investigations, storage, exports). Evidence matching is deterministic keyword/identifier scoring, not semantic retrieval, so every match is explainable. The Anthropic API is called only when the analyst explicitly clicks "Investigate with Claude"; API keys are never logged, displayed, or written to saved results. This is a single-user, local-only, human-in-the-loop tool — it never writes back to a scanner or production system.


### PR DESCRIPTION
## New Listing: Evidence-Backed Vulnerability Investigator

**Repository:** https://github.com/infosecloudninja007/evidence-vulnerability-investigator
**Description:** Streamlit prototype that matches vulnerability scanner findings against local advisory evidence and asks Claude for a structured, evidence-grounded disposition recommendation.

### Checklist
- [x] I have reviewed and accept the [CyberAgents Exchange Contribution Agreement](https://github.com/tenable/cyberagents-exchange/blob/main/docs/CyberAgents_Contribution_Agreement)
- [x] Agent/playbook code is in a personal GitHub repo
- [x] Repo has a README
- [x] Repo has an open source license (MIT)
- [x] Listing file passes schema validation
- [x] Listing placed in correct directory (agents/)
- [x] Filename is a valid slug (evidence-backed-vulnerability-investigator.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)