### PR TITLE
Update listing: AI Secret Scanner - credit all three authors

### DIFF
--- a/skills/ai-secret-scanner.md
+++ b/skills/ai-secret-scanner.md
@@ -1,6 +1,6 @@
 ---
 name: "AI Secret Scanner"
-author: "SDSicuritech"
+author: "Sapan Dhora, Rajesh Guttikonda, Madhusudahan Mergu"
 github_url: "https://github.com/SDSicuritech/TenableAITokenSearch"
 description: "Scans authorized web apps for exposed AI and cloud API keys in client-delivered HTML and JavaScript."
 license: "MIT"


### PR DESCRIPTION
## Update listing: AI Secret Scanner

Updates the `author` field on `skills/ai-secret-scanner.md` (merged in #117) to credit all three authors of the project rather than only the GitHub account that hosts it.

```diff
-author: "SDSicuritech"
+author: "Sapan Dhora, Rajesh Guttikonda, Madhusudahan Mergu"
```

`github_url` is unchanged.

### On the owner-congruence check

Flagging this proactively, since the checklist asks that `github_url` and `author` match the repository remote and owner:

- **Sapan Dhora is `SDSicuritech`**, the owner of the linked repo — so the primary author still resolves to the actual owner.
- **Rajesh Guttikonda and Madhusudahan Mergu are co-authors** who do not own the hosting account. To keep the listing supported by the repository rather than asserting something it doesn't show, I added an `## Authors` section to the repo README naming all three: SDSicuritech/TenableAITokenSearch@3eac6fe
- There is existing precedent for human names in this field rather than bare logins — `"Ahmad Jaber (ABMJ)"` and `"Ash Collins"` are both published listings. This is the first with multiple names, so if you would rather it stay a single login with co-authors credited only in the body and README, say so and I will rework it that way.

`LICENSE` is deliberately unchanged — copyright remains with Sapan Dhora. Authorship and copyright are separate, and I did not want to alter a legal statement as part of a metadata update.

### Validation

`validator.py --path .` → exit 0, `✔ skills/ai-secret-scanner.md is valid.`

I have reviewed and accept the [CyberAgents Contribution Agreement](https://github.com/tenable/cyberagents-exchange/blob/main/docs/CyberAgents_Contribution_Agreement) (originally accepted 2026-08-05T19:02:31Z; unchanged by this update).