### PR TITLE
Add listing: Nessus Agent Coverage Report

### DIFF
--- a/skills/nessus-agent-coverage-report.md
+++ b/skills/nessus-agent-coverage-report.md
@@ -1,0 +1,64 @@
+---
+name: "Nessus Agent Coverage Report"
+author: "conard0-git"
+github_url: "https://github.com/conard0-git/nessus-agent-coverage-report"
+description: "Report Nessus agent coverage by correlating AWS EC2, the Nessus Manager agent list, and Tenable Security Center scan data. Read-only."
+license: "MIT"
+tier: "contributed"
+tags: ["nessus", "tenable", "security-center", "aws", "ec2", "coverage-report", "compliance-reporting", "inventory"]
+integrations: ["AWS", "Tenable"]
+date_added: 2026-08-06
+contribution_agreement_date: 2026-08-06T20:32:58Z
+compatible_platforms: ["Claude Code"]
+invocation: "/nessus-agent-coverage-report"
+---
+
+Report Nessus agent **coverage** — which live hosts have an agent, and (more
+importantly) which do not. The skill correlates three data sources so a host
+is only called a gap when it's genuinely live and genuinely un-agented:
+the live cloud fleet (AWS EC2), optional on-premise subnets, and the Nessus
+Manager agent inventory. Cross-references Tenable Security Center so a host
+that is being *scanned* but has no installed agent is still surfaced. This
+is the inverse of stale-agent cleanup: cleanup removes agents whose host is
+gone; this finds hosts that exist but have no agent.
+
+## What it does
+
+- **Cloud fleet enumeration.** Pull running EC2 instances across all
+  configured profiles/regions and capture primary private IP, primary public
+  IP, Name tag, VPC, and launch date.
+- **Nessus agent inventory.** Pull every installed agent from the Nessus
+  Manager, normalizing status to online/offline (online wins on IP
+  collisions).
+- **Tenable Security Center enrichment.** Query each configured repository
+  for its IP set (`sumip` analysis) — for cloud hosts this flags "scanned
+  but un-agented" vs. "invisible"; for on-premise hosts it *is* the
+  inventory source, with the on-prem universe defined as scanned IPs
+  inside a caller-supplied CIDR list.
+- **Match by identifier ladder.** Primary private IP → primary public IP →
+  Name tag / hostname, so a host isn't falsely flagged as missing just
+  because its agent registered under a different identifier.
+- **Exclusions.** Honor an exclusion list (IPs or CIDRs, from a file or an
+  env value) for hosts that intentionally can't or shouldn't carry an
+  agent, so they don't appear as false gaps.
+- **Excel coverage report.** Dashboard (totals, matched, missing after
+  exclusions, on-prem breakdown) + an "EC2 hosts missing an agent" sheet
+  (sorted by AWS profile then instance name) + an "on-prem hosts missing/
+  offline" sheet (missing first, then most-recently-seen). Hosts in a
+  configurable set of VPCs can be split onto a separate tab.
+
+## How it works
+
+The design guarantee is that the workflow is **read-only** — it never
+installs, removes, or modifies agents; it only reports. Correlation runs on
+three data sources merged into a single view: cloud says which hosts *should*
+have an agent (or on-prem CIDRs + SC scan data does), the Nessus Manager
+says which hosts *do*, and Security Center enrichment closes the gap on
+"scanned but un-agented" so purely-invisible hosts and merely-un-agented
+ones are distinguished. Configuration is entirely environment-variable
+driven — cloud credentials/profiles/regions, Nessus URL + keys, optional SC
+URL + keys + repository IDs, optional on-prem CIDR list, optional
+exclusions — with no hardcoded secrets, hosts, CIDRs, or repo IDs. See
+`SKILL.md` for the full workflow, `references/coverage-correlation.md` for
+the matching + classification logic, and `references/reporting-and-exclusions.md`
+for the Excel structure and exclusion model.

--- a/skills/nessus-agent-coverage-report.md
+++ b/skills/nessus-agent-coverage-report.md
@@ -62,3 +62,39 @@ exclusions — with no hardcoded secrets, hosts, CIDRs, or repo IDs. See
 `SKILL.md` for the full workflow, `references/coverage-correlation.md` for
 the matching + classification logic, and `references/reporting-and-exclusions.md`
 for the Excel structure and exclusion model.
+
+## Example usage
+
+Once installed and configured (see the linked repo's README for prerequisites
+and environment variables), invoke the skill from Claude Code by name:
+
+**Bare invocation — uses everything from the environment:**
+
+```
+/nessus-agent-coverage-report
+```
+
+**Cloud-only run — skip on-prem when Security Center isn't configured:**
+
+```
+/nessus-agent-coverage-report cloud only, no on-prem
+```
+
+**Split a subset of VPCs onto a separate report tab:**
+
+```
+/nessus-agent-coverage-report split VPCs vpc-abc123, vpc-def456 onto their own tab
+```
+
+**Point at a specific exclusion file:**
+
+```
+/nessus-agent-coverage-report use exclusions from ~/nessus-exclusions.txt
+```
+
+Output is a dated Excel workbook (default `Nessus_Agent_Coverage_YYYYMMDD.xlsx`)
+with a coverage dashboard, an EC2-missing sheet, an on-prem missing/offline
+sheet, and an optional separate-VPC tab, plus a color-coded console summary.
+See the linked repo's README for known limitations (primary-NIC-only matching,
+on-prem coverage requiring Security Center + a CIDR list, running-EC2-only
+inventory, IP/CIDR-based exclusions, and other scope boundaries).

--- a/skills/nessus-agent-coverage-report.md
+++ b/skills/nessus-agent-coverage-report.md
@@ -1,4 +1,5 @@
 ---
+last_reviewed: 2026-08-20
 name: "Nessus Agent Coverage Report"
 author: "conard0-git"
 github_url: "https://github.com/conard0-git/nessus-agent-coverage-report"
@@ -12,6 +13,7 @@ contribution_agreement_date: 2026-08-06T20:32:58Z
 compatible_platforms: ["Claude Code"]
 invocation: "/nessus-agent-coverage-report"
 ---
+last_reviewed: 2026-08-20
 
 Report Nessus agent **coverage** — which live hosts have an agent, and (more
 importantly) which do not. The skill correlates three data sources so a host


### PR DESCRIPTION
## New Listing: Nessus Agent Coverage Report

**Repository:** https://github.com/conard0-git/nessus-agent-coverage-report
**Description:** Report Nessus agent coverage by correlating AWS EC2, the Nessus Manager agent list, and Tenable Security Center scan data. Read-only.

### Checklist
- [x] I have reviewed and accept the [CyberAgents Exchange Contribution Agreement](https://github.com/tenable/cyberagents-exchange/blob/main/docs/CyberAgents_Contribution_Agreement)
- [x] Skill code is in a personal GitHub repo
- [x] Repo has a README
- [x] Repo has an open source license (MIT)
- [x] Listing file passes schema validation
- [x] Listing placed in correct directory (skills/)
- [x] Filename is a valid slug (nessus-agent-coverage-report.md)

_(Recreated from a fresh fork after the previous fork was accidentally detached; content unchanged. Supersedes closed PR #126.)_