### PR TITLE
Add listing: Exploit Availability Check

### DIFF
--- a/skills/exploit-availability-check.md
+++ b/skills/exploit-availability-check.md
@@ -1,4 +1,5 @@
 ---
+last_reviewed: 2026-08-13
 name: "Exploit Availability Check"
 author: "kevinmhorvath"
 github_url: "https://github.com/kevinmhorvath/exploit-availability-check"

--- a/skills/exploit-availability-check.md
+++ b/skills/exploit-availability-check.md
@@ -1,0 +1,35 @@
+---
+name: "Exploit Availability Check"
+author: "kevinmhorvath"
+github_url: "https://github.com/kevinmhorvath/exploit-availability-check"
+description: "Given a CVE or vuln name, reports an exploit-maturity tier and in-the-wild status from CISA KEV, EPSS, Metasploit, Nuclei, Exploit-DB, and GitHub PoC trackers."
+license: "MIT"
+tier: "contributed"
+tags: ["vulnerability-management", "exploit-intelligence", "cve", "threat-prioritization", "kev", "epss", "patch-prioritization"]
+integrations: ["Rapid7"]
+date_added: 2026-08-07
+contribution_agreement_date: 2026-08-07T19:57:11Z
+compatible_platforms: ["Claude Code", "Claude Cowork"]
+invocation: "Ask about a CVE or named vuln, e.g. 'is CVE-2021-44228 weaponized?' or 'any PoC for Log4Shell?'"
+---
+
+## What it does
+
+Exploit Availability Check answers the single question that drives real-world patch triage: **is this vulnerability weaponized right now?** Given a CVE ID — or a named vulnerability such as Log4Shell, Zerologon, or BlueKeep — it returns an **exploit-maturity tier** (Weaponized → Public working exploit → Proof-of-concept only → No public exploit found) and, reported separately, whether the CVE is **being exploited in the wild**.
+
+It is strictly a defensive prioritization aid. It locates and rates the maturity of *already-public* exploit material so defenders can decide what to patch first; it does not write exploit code, weaponize proofs-of-concept, or provide exploitation steps, and its guardrails explicitly refuse those requests.
+
+The skill runs against public, open-source data with no API keys, caches the large feeds locally for sub-second repeat lookups, and can emit a client-ready Markdown + CSV report for an entire CVE list at once.
+
+## How it works
+
+For each CVE the skill consults seven public sources and maps every result to structured data:
+
+- **CISA KEV** — known exploited-in-the-wild status and ransomware-campaign flag.
+- **FIRST EPSS** — 30-day exploitation-probability score and percentile.
+- **Metasploit** (rapid7/metasploit-framework, BSD-3) — packaged module metadata, distinguishing exploit and `auxiliary/admin` modules from mere scanners and surfacing each module's reliability rank.
+- **Nuclei** (projectdiscovery/nuclei-templates, MIT) — whether a detection/verification template ships.
+- **Exploit-DB** — archived exploit entries and their verified flag.
+- **nomi-sec/PoC-in-GitHub** and **trickest/cve** — star-ranked GitHub proof-of-concept repositories.
+
+It then assigns a baseline maturity tier from those signals and refines it by reading repository substance (star counts and descriptions distinguish real exploits from patch scripts, scanners, and write-ups), always reporting in-the-wild status separately from public code maturity because the two frequently diverge — for example, a KEV-listed 0-day whose only public code is a crasher. Because the underlying feeds can lag real-world activity and absence of public code never proves a vulnerability is unexploitable, the skill states those limitations in its output.


### PR DESCRIPTION
## New Listing: Exploit Availability Check

**Repository:** https://github.com/kevinmhorvath/exploit-availability-check
**Description:** Given a CVE or vuln name, reports an exploit-maturity tier and in-the-wild status from CISA KEV, EPSS, Metasploit, Nuclei, Exploit-DB, and GitHub PoC trackers.

### Checklist
- [x] I have reviewed and accept the [CyberAgents Exchange Contribution Agreement](https://github.com/tenable/cyberagents-exchange/blob/main/docs/CyberAgents_Contribution_Agreement)
- [x] Agent/playbook code is in a personal GitHub repo
- [x] Repo has a README
- [x] Repo has an open source license (MIT)
- [x] Listing file passes schema validation
- [x] Listing placed in correct directory (skills/)
- [x] Filename is a valid slug (exploit-availability-check.md)