### PR TITLE
Fix Python version floor (3.8+ -> 3.7+) in Cloud External Attack-Path Suite listing

### DIFF
--- a/agents/cloud-ext-attack-path-suite.md
+++ b/agents/cloud-ext-attack-path-suite.md
@@ -91,7 +91,7 @@ are kept out of version control.
 
 ## Requirements
 
-- **MCP edition:** the Tenable Cloud Security `tcs` MCP connector; Python 3.8+ (stdlib
+- **MCP edition:** the Tenable Cloud Security `tcs` MCP connector; Python 3.7+ (stdlib
   only).
 - **API-token edition:** a Tenable Cloud Security API token; `bash`, `curl`, `jq`;
-  Python 3.8+ (stdlib only).
+  Python 3.7+ (stdlib only).


### PR DESCRIPTION
Documentation correction to an existing listing — no new submission, no frontmatter changes.

## What's wrong

`agents/cloud-ext-attack-path-suite.md` states **Python 3.8+** for both editions in the Requirements section. The actual floor is **3.7**. The linked repository's own `README.md` and its in-repo copy of this listing already say 3.7+, so the published listing is the only place carrying the wrong number.

## Why 3.7 is the right number (verified, not assumed)

- The linked repo's CI has a dedicated **`Python 3.7 (stdlib-only suite)`** job, green on `main`.
- The full 26-section test suite passes on **Python 3.7.3** in a `debian:buster-slim` container (the oldest environment the suite targets, also exercising curl 7.64.0 / old jq).
- Both editions are stdlib-only, so there is no dependency floor above the interpreter's.

Overstating the floor as 3.8 would turn away users on a supported interpreter.

## Scope

Two lines, text only:

```diff
-- **MCP edition:** the Tenable Cloud Security `tcs` MCP connector; Python 3.8+ (stdlib
+- **MCP edition:** the Tenable Cloud Security `tcs` MCP connector; Python 3.7+ (stdlib
   only).
 - **API-token edition:** a Tenable Cloud Security API token; `bash`, `curl`, `jq`;
-  Python 3.8+ (stdlib only).
+  Python 3.7+ (stdlib only).
```

Frontmatter is untouched — `tier`, `date_added`, `last_reviewed`, and `contribution_agreement_date` (`2026-08-04T02:33:29Z`, from the original accepted submission in #106) all carry forward unchanged.

## How this was found

A quality review of the linked repository against `docs/contributing_checklist.md` flagged the documented-vs-actual mismatch. The other findings from that review were code defects and are already fixed and merged in the linked repo (Echo6Bravo/cloud-ext-attack-path-suite#6); this listing wording was the only item that required a change here.
