### PR TITLE
Add "Listed on CyberAgents Exchange" badge for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,6 +229,14 @@ If anything needs attention, you'll receive specific feedback as a review commen
 
 All pull requests are merged using **squash and merge** — the entire PR is combined into a single commit on `main`. Merge commits and rebase merges are disabled, so squash is the only option. The squash commit uses your PR title and description, so please keep them clear and descriptive. The source branch is deleted automatically after the merge.
 
+### Add the Badge
+
+Once your listing is merged, add the "Listed on CyberAgents Exchange" badge to your own README — see [Show It Off](README.md#show-it-off) for the pitch and the profile page link.
+
+```markdown
+[![Listed on CyberAgents Exchange](https://img.shields.io/badge/CyberAgents%20Exchange-Listed-E7FF00?style=flat-square&labelColor=1E2426)](https://exchange.tenable.com/)
+```
+
 ## Things That Will Get Your Submission Rejected
 
 Regardless of how well-formatted your listing is, submissions are rejected outright if they involve:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,27 @@ Before you start, your project needs:
 
 See the [Contribute page](https://exchange.tenable.com/contributing/) for a walkthrough.
 
+## Show It Off
+
+Once your listing goes live, add this badge to your README to showcase your contribution.
+
+[![Listed on CyberAgents Exchange](https://img.shields.io/badge/CyberAgents%20Exchange-Listed-E7FF00?style=flat-square&labelColor=1E2426)](https://exchange.tenable.com/)
+
+```markdown
+[![Listed on CyberAgents Exchange](https://img.shields.io/badge/CyberAgents%20Exchange-Listed-E7FF00?style=flat-square&labelColor=1E2426)](https://exchange.tenable.com/)
+```
+
+Also, every contributor gets a profile page at `exchange.tenable.com/contributors/<your-github-handle>`!
+
+<details>
+<summary>HTML variant</summary>
+
+```html
+<a href="https://exchange.tenable.com/"><img src="https://img.shields.io/badge/CyberAgents%20Exchange-Listed-E7FF00?style=flat-square&labelColor=1E2426" alt="Listed on CyberAgents Exchange"></a>
+```
+
+</details>
+
 ## Repository Layout
 
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 </p>
 
 <p align="center">
+  <a href="https://exchange.tenable.com/discord"><img src="https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://x.com/CyberAgentEx"><img src="https://img.shields.io/badge/follow-%40CyberAgentEx-000000?style=flat-square&logo=x&logoColor=white" alt="X"></a>
   <a href="https://www.youtube.com/@CyberAgentEx"><img src="https://img.shields.io/badge/YouTube-%40CyberAgentEx-FF0000?style=flat-square&logo=youtube&logoColor=white" alt="YouTube"></a>
 </p>
@@ -109,10 +110,11 @@ More at [exchange.tenable.com/about](https://exchange.tenable.com/about/).
 
 ## Questions & Support
 
+- **Community chat** — [join us on Discord](https://exchange.tenable.com/discord) for questions, help, and what's landing next
 - **General questions** — visit [exchange.tenable.com](https://exchange.tenable.com/)
 - **Issues & feature requests** — [open a GitHub issue](https://github.com/tenable/cyberagents-exchange/issues)
 - **Security concerns with a listed contribution** — reach out to the repository owner; if needed, use [GitHub Security Advisories](https://docs.github.com/en/code-security/concepts/vulnerability-reporting-and-management/repository-security-advisories)
 
-Follow along on [X](https://x.com/CyberAgentEx) and [YouTube](https://www.youtube.com/@CyberAgentEx).
+Come hang out on [Discord](https://exchange.tenable.com/discord), and follow along on [X](https://x.com/CyberAgentEx) and [YouTube](https://www.youtube.com/@CyberAgentEx).
 
 Listings are licensed by their respective authors — check each linked repository for its license. See [SECURITY.md](SECURITY.md) and the [CyberAgents Contribution Agreement](docs/CyberAgents_Contribution_Agreement).


### PR DESCRIPTION
## Summary

Gives contributors a shields.io badge to put on their own README once their listing is merged, and a doc pointer to it in the post-merge flow:

- `README.md` — new **Show It Off** section (between *Contributing* and *Repository Layout*) with the rendered badge, the markdown snippet, a short pitch, and a collapsed HTML variant for centered badge rows.
- `CONTRIBUTING.md` — new **Add the Badge** subsection under *How PRs Are Merged*, linking to `README.md#show-it-off`.

One shared badge, identical for every contributor — no per-listing slugs. Links to `https://exchange.tenable.com/`.

## Test plan

- [x] Badge URL resolves: `curl -sI` returns `200` / `image/svg+xml` for the `img.shields.io` endpoint
- [x] `uv run ./validator.py` passes with zero errors