### PR TITLE
Add listing: SecHelix

### DIFF
--- a/skills/sechelix.md
+++ b/skills/sechelix.md
@@ -9,6 +9,7 @@ tags: ["appsec", "secure-code-review", "authorization", "bola", "idor", "busines
 integrations: ["Anthropic"]
 date_added: 2026-09-09
 contribution_agreement_date: 2026-09-09T00:00:00Z
+last_reviewed: 2026-09-10
 works_with_tenable_hexa_mcp: false
 compatible_platforms: ["Claude Code", "Codex", "Gemini CLI", "GitHub Copilot"]
 invocation: "sechelix"

--- a/skills/sechelix.md
+++ b/skills/sechelix.md
@@ -1,0 +1,82 @@
+---
+name: "SecHelix"
+author: "omarmohelal"
+github_url: "https://github.com/omarmohelal/SecHelix"
+description: "Evidence-first application-security review skill that sends every candidate finding to an independent verifier whose job is to disprove it before it is reported."
+license: "Apache-2.0"
+tier: "contributed"
+tags: ["appsec", "secure-code-review", "authorization", "bola", "idor", "business-logic", "false-positive-reduction", "supply-chain", "ai-security", "devsecops"]
+integrations: ["Anthropic"]
+date_added: 2026-09-09
+contribution_agreement_date: 2026-09-09T00:00:00Z
+works_with_tenable_hexa_mcp: false
+compatible_platforms: ["Claude Code", "Codex", "Gemini CLI", "GitHub Copilot"]
+invocation: "sechelix"
+---
+
+Most review tooling optimises for finding more. The expensive failure in
+application security is the opposite one: a queue of confident findings that
+nobody can act on, because a third of them are wrong and there is no cheap way
+to tell which third. SecHelix is built around that asymmetry.
+
+## What it does
+
+SecHelix reviews a codebase, pull request, API, cloud configuration or
+agent/MCP integration you own or are explicitly authorized to test, and returns
+findings that carry their own evidence — plus an explicit list of the candidates
+it *refuted*, and why.
+
+The refuted list is the point. A review that reports six issues and shows the
+eleven it disproved is a different artifact from one that reports six and stays
+silent about its own uncertainty.
+
+Coverage emphasis is the classes that static pattern matching handles worst:
+object and function authorization (BOLA, IDOR, BFLA), tenant isolation,
+business-logic and entitlement abuse, payment and ledger invariants, race
+conditions and idempotency, secret handling, SSRF and outbound-fetch
+boundaries, supply chain, and the prompt/tool/authorization boundaries of AI
+agents and MCP servers.
+
+## How it works
+
+Scope and mode are fixed first. Execution is one of `STATIC`, `LOCAL`,
+`STAGING`, `PRODUCTION_SAFE`, or `UNTRUSTED_REPO` — the last treats repository
+content as data and never as control instructions, so a `CLAUDE.md` or
+`AGENTS.md` in the reviewed repository cannot redirect the review of itself.
+
+The workflow then maps the attack surface and trust boundaries, resolves which
+checks actually apply, and runs specialist review lanes in parallel. Every lane
+produces *candidates* — never findings. Candidates go to an independent
+verifier that reconstructs the claim from the code without assuming it is
+correct, and reports `VERIFIED`, `REFUTED`, `UNPROVEN` or `BLOCKED`.
+
+Three properties make the output usable rather than merely long:
+
+**Missing evidence is not absence.** Applicability resolves to `APPLICABLE`,
+`NOT_APPLICABLE`, `UNKNOWN` or `BLOCKED`. A check that could not run is
+recorded as one that could not run.
+
+**High and Critical findings require regression proof.** A fix is not complete
+because the code changed. It is complete when a test that failed before the fix
+passes after it, and the original finding no longer reproduces.
+
+**The release gate is fail-closed.** It returns `PASS`,
+`PASS_WITH_KNOWN_RISK`, `BLOCKED` or `INCOMPLETE`. A run whose lanes were
+blocked returns `INCOMPLETE` — never a clean `PASS`. Silence is never rendered
+as safety.
+
+## Prerequisites and limitations
+
+The skill is the product and runs on the agent alone. An optional Python
+runtime (`pipx install sechelix`) adds stored runs, a coverage ledger of what
+previous runs did *not* examine, replayable evidence, SARIF/HTML/Markdown
+reports, CI exit codes, and a read-only MCP adapter with no shell tool and
+path arguments confined to a configured root.
+
+Limitations, stated plainly: SecHelix reasons over code and configuration and
+inherits the judgment limits of the model driving it. It is not a substitute
+for a penetration test, and it makes no measured detection-rate claim — the
+public benchmark position is `NOT_MEASURED`, deliberately, rather than a
+flattering number produced by grading its own homework. It is for systems you
+own or are authorized to assess, and it carries no exploitation, lateral
+movement, or exfiltration capability.


### PR DESCRIPTION
I have reviewed and accept the [CyberAgents Contribution Agreement](https://github.com/tenable/cyberagents-exchange/blob/main/docs/CyberAgents_Contribution_Agreement).

## What it is

SecHelix is an evidence-first application-security review skill for repositories and environments you own or are explicitly authorized to test. Every candidate finding goes to an independent verifier whose job is to disprove it before it is reported, and the report includes the candidates it *refuted* and why.

The refuted list is the point. Most review tooling optimises for finding more; the expensive failure in AppSec is the opposite one — a queue of confident findings where a third are wrong and there is no cheap way to tell which third.

Coverage emphasis is the classes static pattern matching handles worst: BOLA/IDOR/BFLA, tenant isolation, business-logic and entitlement abuse, payment and ledger invariants, races and idempotency, secret handling, SSRF, supply chain, and the prompt/tool/authorization boundaries of AI agents and MCP servers.

## Against the contributing checklist

| Item | Status |
|---|---|
| Public GitHub repository, personal account | `omarmohelal/SecHelix`, not an EMU account |
| Open-source licence | Apache-2.0, `LICENSE` at root |
| No secrets in git history | `scripts/check_no_secrets.py` runs on every CI push |
| README covers purpose, prerequisites, how to run, outputs, limitations | Yes, including an explicit limitations section |
| Installation instructions are accurate | `npx skills@latest add omarmohelal/SecHelix --skill sechelix` and `pipx install sechelix` both verified from a clean environment today |
| Metadata reflects the repository | `compatible_platforms` lists only the four adapters that actually ship |
| Claims supported by repository content | See below |

## On the claims in the listing

The listing says the MCP adapter is read-only, has no shell, and confines paths to a configured root. Rather than ask you to take that on trust, `tests/test_server_json.py` asserts it: no `subprocess`/`os.system`/`os.popen` reachable from the adapter, no tool name that reads as command execution, and path confinement actually refusing `../..`, absolute paths and symlink-style escapes.

Verified from a clean PyPI install while writing this: 7 tools, and `path: "../../.."` refused with `resolves outside the configured root`.

## What is deliberately not claimed

There is no detection-rate number. The public benchmark position is `NOT_MEASURED` and stays that way until an uncontaminated evaluator runs a reproducible packet — the project is not going to grade its own homework and publish the score. A 76-case blind-label result is published with an explicit boundary saying it describes the label task, not the complete workflow. No competitor comparison appears anywhere in the repository.

There is a separate [challenge repository](https://github.com/omarmohelal/sechelix-challenge) with ten cases, three of them decoys, where a false positive costs exactly what a miss costs. It is deliberately tool-neutral.

## Nothing on the rejection list

No offensive or weaponized capability — no exploitation, lateral movement, persistence or exfiltration. No hardcoded secrets. No undisclosed outbound calls: the optional runner has an **empty dependency list** and defaults to `network_mode: DENY`. Nothing targets a third party, and nothing weakens a security control.

## Try it in 90 seconds

```bash
git clone https://github.com/omarmohelal/SecHelix && cd SecHelix
python examples/expense-api/prove.py
```

Python 3.10+, no dependencies, no network, no containers. Two candidates in a small multi-tenant API: one real cross-tenant read that scanners walk past because the endpoint *does* have an authorization check — it just checks the wrong thing — and one f-string SQL construction that every pattern matcher flags and that is not exploitable at all.