### PR TITLE
Add listing: SHPBL Agent Behaviour Drift Sentinel

### DIFF
--- a/mcp-servers/shpbl-drift-sentinel.md
+++ b/mcp-servers/shpbl-drift-sentinel.md
@@ -1,0 +1,44 @@
+---
+name: "Agent Behaviour Drift Sentinel"
+author: "SweetKenneth"
+github_url: "https://github.com/SweetKenneth/shpbl-drift-sentinel"
+description: "Signs a baseline of how an agent normally behaves, then reports divergence with dimension-level attribution, episode replay, honest confidence and operator-approved calibration."
+license: "MIT"
+tier: "contributed"
+tags: ["ai-agent-security", "drift-detection", "behavioural-baseline", "detection-engineering", "anomaly", "governance", "deterministic", "mcp"]
+integrations: []
+date_added: 2026-09-11
+contribution_agreement_date: 2026-09-11T21:33:55Z
+works_with_tenable_hexa_mcp: false
+transport: "stdio"
+runtime: "bun"
+auth_method: "none"
+compatible_clients: ["Claude Code", "Claude Desktop", "Cursor"]
+tools_exposed:
+  - name: "ingest_traces"
+    description: "Ingest caller-supplied agent execution traces and return a trace set reference"
+  - name: "set_baseline"
+    description: "Sign and store a behaviour profile as a named baseline version"
+  - name: "check_drift"
+    description: "Compare a trace set against a signed baseline and report divergence"
+  - name: "explain_drift"
+    description: "Dimension-level attribution plus replay of the most divergent episode"
+  - name: "calibrate"
+    description: "Propose a calibration profile from labelled findings; never mutates thresholds"
+  - name: "apply_calibration"
+    description: "Create a new signed baseline version carrying an approved calibration profile"
+  - name: "configure_suppression"
+    description: "Declare maintenance windows and known change markers"
+resources_exposed: []
+prompts_exposed: []
+---
+
+A compromised or manipulated agent rarely announces itself with a single malicious call. It starts reaching for different tools, touching different resources, running longer, failing differently. This server captures what normal looked like — signed, versioned, and immutable — so the change is visible and arguable.
+
+## What it does
+
+Operators hand in execution traces, freeze a behaviour profile as a signed baseline version, and afterwards compare fresh traces against it. A drift finding says which behavioural dimensions moved, by how much, and which single episode diverged most, and it can replay that episode for review. Confidence is reported honestly: when the sample is too small to support a conclusion, the finding still carries a severity but the severity is capped at informational rather than inflated. False positives are handled the way detection engineering actually works — an analyst labels findings, `calibrate` proposes a profile without changing anything, and only `apply_calibration` creates a new signed baseline version carrying that profile, so every threshold change is attributable. Maintenance windows and known change markers can be declared so an expected deployment does not read as an attack.
+
+## How it works
+
+A zero-dependency stdio MCP server written from a public behaviour specification. Baselines are signed through a caller-registered key adapter and are versioned rather than edited, so history cannot be rewritten to make a finding disappear. Comparison is deterministic: the same traces against the same baseline yield the same finding, which is what makes replay and review meaningful. No model call, no network egress, no telemetry; traces are supplied by the caller rather than collected by the server. Known limitation stated in the repository — a baseline captures only what the supplied traces contained, so behaviour that was already abnormal when the baseline was taken will look normal afterwards. Conformance tests cover the numbered specification properties, including the insufficient-confidence severity cap.


### PR DESCRIPTION
## New Listing: Agent Behaviour Drift Sentinel

**Repository:** https://github.com/SweetKenneth/shpbl-drift-sentinel
**Description:** Signs a baseline of how an agent normally behaves, then reports divergence with dimension-level attribution, episode replay, honest confidence and operator-approved calibration.

### Checklist
- [x] I have reviewed and accept the [CyberAgents Exchange Contribution Agreement](https://github.com/tenable/cyberagents-exchange/blob/main/docs/CyberAgents_Contribution_Agreement)
- [x] Code is in a personal GitHub repo
- [x] Repo has a README
- [x] Repo has an open source license (MIT)
- [x] Listing file passes schema validation (`validator.py` run locally: valid)
- [x] Listing placed in correct directory (mcp-servers/)
- [x] Filename is a valid slug (shpbl-drift-sentinel.md)

### Congruence notes for the reviewer
- `runtime: bun` — `package.json` with Bun/Node run instructions; zero runtime dependencies
- `transport: stdio` — stdio MCP server; JSON configuration example in README
- `auth_method: none` — no credentials accepted; baselines are signed through a caller-registered key adapter
- `tools_exposed` — 7 tools, matching the server implementation (`ingest_traces`, `set_baseline`, `check_drift`, `explain_drift`, `calibrate`, `apply_calibration`, `configure_suppression`)
- `works_with_tenable_hexa_mcp: false` — standalone; no Tenable integration claimed
- Deterministic comparison: same traces against same baseline yield the same finding; when the sample is too small the severity is capped at informational rather than inflated
- No model call, no network egress, no telemetry; traces are caller-supplied
- 28 tests / 118 assertions passing; conformance tests cover the numbered specification properties including the insufficient-confidence severity cap
- Known limitation stated in the repo: a baseline captures only what the supplied traces contained